### PR TITLE
Add logo and improve frontend layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,30 +1,35 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="fr">
-<head>
-  <meta charset="UTF-8" />
-  <title>Formulaire Keystroke</title>
-  <link rel="stylesheet" href="style.css" />
-</head>
-<body>
-  <div class="container">
-    <h1>Formulaire Keystroke</h1>
-    <p class="subtitle">Analyse en temps réel de tes frappes clavier</p>
-    <form id="keystroke-form">
-      <label>Nom :</label>
-      <input type="text" id="lastname" required />
+  <head>
+    <meta charset="UTF-8" />
+    <title>Formulaire Keystroke</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <header class="header">
+      <img src="logo.svg" alt="Logo" class="logo" />
+      <h1>Keystroke Analyzer</h1>
+    </header>
 
-      <label>Prénom :</label>
-      <input type="text" id="firstname" required />
+    <div class="container">
+      <h2>Formulaire</h2>
+      <p class="subtitle">Analyse en temps réel de tes frappes clavier</p>
+      <form id="keystroke-form">
+        <label>Nom :</label>
+        <input type="text" id="lastname" required />
 
-      <label>Email :</label>
-      <input type="email" id="email" required />
+        <label>Prénom :</label>
+        <input type="text" id="firstname" required />
 
-      <label>Mot de passe :</label>
-      <input type="password" id="password" required />
+        <label>Email :</label>
+        <input type="email" id="email" required />
 
-      <button type="submit">Soumettre</button>
-    </form>
-  </div>
-  <script src="script.js"></script>
-</body>
+        <label>Mot de passe :</label>
+        <input type="password" id="password" required />
+
+        <button type="submit">Soumettre</button>
+      </form>
+    </div>
+    <script src="script.js"></script>
+  </body>
 </html>

--- a/logo.svg
+++ b/logo.svg
@@ -1,0 +1,4 @@
+<svg width="60" height="60" viewBox="0 0 60 60" xmlns="http://www.w3.org/2000/svg">
+  <rect width="60" height="60" rx="10" fill="#007BFF"/>
+  <text x="50%" y="55%" text-anchor="middle" font-family="Arial, sans-serif" font-size="28" fill="white">KA</text>
+</svg>

--- a/result.html
+++ b/result.html
@@ -1,37 +1,45 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="fr">
-<head>
-  <meta charset="UTF-8" />
-  <title>Résumé Keystroke</title>
-  <link rel="stylesheet" href="style.css" />
-  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-</head>
-<body>
-  <div class="container">
-    <h1>📊 Résumé des frappes clavier</h1>
-    <div id="results"></div>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Résumé Keystroke</title>
+    <link rel="stylesheet" href="style.css" />
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  </head>
+  <body>
+    <header class="header">
+      <img src="logo.svg" alt="Logo" class="logo" />
+      <h1>Keystroke Analyzer - Résumé</h1>
+    </header>
 
-    <canvas id="keystrokeChart" style="max-width: 100%; margin-top: 40px;"></canvas>
+    <div class="container">
+      <h2>📊 Résumé des frappes clavier</h2>
+      <div id="results"></div>
 
-    <a href="index.html">↩ Recommencer</a>
-  </div>
+      <canvas
+        id="keystrokeChart"
+        style="max-width: 100%; margin-top: 40px"
+      ></canvas>
 
-  <script>
-    const data = JSON.parse(localStorage.getItem("keystrokeData") || "{}");
-    const container = document.getElementById("results");
+      <a href="index.html" class="button-link">↩ Recommencer</a>
+    </div>
 
-    const labels = [];
-    const counts = [];
-    const times = [];
+    <script>
+      const data = JSON.parse(localStorage.getItem("keystrokeData") || "{}");
+      const container = document.getElementById("results");
 
-    for (let field in data) {
-      const stats = data[field];
+      const labels = [];
+      const counts = [];
+      const times = [];
 
-      labels.push(field);
-      counts.push(stats.count);
-      times.push(stats.time.toFixed(2));
+      for (let field in data) {
+        const stats = data[field];
 
-      container.innerHTML += `
+        labels.push(field);
+        counts.push(stats.count);
+        times.push(stats.time.toFixed(2));
+
+        container.innerHTML += `
         <div class="result-block">
           <h3>${field}</h3>
           <p><strong>Texte :</strong> ${stats.text}</p>
@@ -42,40 +50,40 @@
           <p><strong>Temps (s) :</strong> ${stats.time.toFixed(2)}</p>
         </div>
       `;
-    }
-
-    // Création du graphique
-    const ctx = document.getElementById("keystrokeChart").getContext("2d");
-    const chart = new Chart(ctx, {
-      type: "bar",
-      data: {
-        labels: labels,
-        datasets: [
-          {
-            label: "Nombre de frappes",
-            data: counts,
-            backgroundColor: "#007BFF"
-          },
-          {
-            label: "Temps passé (s)",
-            data: times,
-            backgroundColor: "#28a745"
-          }
-        ]
-      },
-      options: {
-        responsive: true,
-        plugins: {
-          legend: {
-            position: "bottom"
-          },
-          title: {
-            display: true,
-            text: "Statistiques par champ"
-          }
-        }
       }
-    });
-  </script>
-</body>
+
+      // Création du graphique
+      const ctx = document.getElementById("keystrokeChart").getContext("2d");
+      const chart = new Chart(ctx, {
+        type: "bar",
+        data: {
+          labels: labels,
+          datasets: [
+            {
+              label: "Nombre de frappes",
+              data: counts,
+              backgroundColor: "#007BFF",
+            },
+            {
+              label: "Temps passé (s)",
+              data: times,
+              backgroundColor: "#28a745",
+            },
+          ],
+        },
+        options: {
+          responsive: true,
+          plugins: {
+            legend: {
+              position: "bottom",
+            },
+            title: {
+              display: true,
+              text: "Statistiques par champ",
+            },
+          },
+        },
+      });
+    </script>
+  </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -1,18 +1,33 @@
+@import url("https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap");
+
 body {
-  font-family: 'Segoe UI', sans-serif;
-  background: linear-gradient(135deg, #f4f6f8, #dce3ea);
+  font-family: "Poppins", sans-serif;
+  background: linear-gradient(135deg, #e5f1ff, #fff);
   margin: 0;
   padding: 0;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  margin-top: 2rem;
+}
+
+.logo {
+  width: 60px;
+  height: 60px;
 }
 
 .container {
   width: 90%;
   max-width: 650px;
   margin: auto;
-  background: white;
+  background: #ffffff;
   padding: 2rem 2.5rem;
-  margin-top: 3rem;
-  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.15);
+  margin-top: 2rem;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.1);
   border-radius: 15px;
 }
 
@@ -20,6 +35,14 @@ h1 {
   text-align: center;
   color: #2c3e50;
   margin-bottom: 0.5rem;
+}
+
+h2 {
+  text-align: center;
+  color: #2c3e50;
+  margin-top: 0;
+  margin-bottom: 1rem;
+  font-size: 1.5rem;
 }
 
 .subtitle {
@@ -36,7 +59,8 @@ label {
   color: #333;
 }
 
-input, textarea {
+input,
+textarea {
   width: 100%;
   padding: 10px;
   margin-top: 0.3rem;
@@ -55,7 +79,7 @@ textarea {
 button {
   margin-top: 2rem;
   width: 100%;
-  background: #007BFF;
+  background: #007bff;
   color: white;
   padding: 0.9rem;
   border: none;
@@ -72,7 +96,7 @@ button:hover {
 .result-block {
   background: #f9f9f9;
   padding: 1rem;
-  border-left: 5px solid #007BFF;
+  border-left: 5px solid #007bff;
   margin-bottom: 1.5rem;
   border-radius: 8px;
 }
@@ -80,9 +104,21 @@ button:hover {
 a {
   display: inline-block;
   margin-top: 20px;
-  color: #007BFF;
+  color: #007bff;
   text-decoration: none;
   font-weight: bold;
+}
+
+a.button-link {
+  background: #007bff;
+  color: #fff;
+  padding: 0.7rem 1.2rem;
+  border-radius: 8px;
+  transition: background 0.3s;
+}
+
+a.button-link:hover {
+  background: #0056b3;
 }
 
 a:hover {


### PR DESCRIPTION
## Summary
- redesign the index and result pages with a new header and logo
- update layout and colors with improved CSS styles
- include a simple SVG logo

## Testing
- `npx prettier -w index.html result.html style.css script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6848bf15b2408323956e76ac95af8599